### PR TITLE
fix reference Integer being to big

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2020-12-29
+
+### Fixed
+
+- Fixed a bug that when the number was too big the check digits would be incorrect.
+
 ## [0.1.0] - 2020-12-29
 
 ### Added

--- a/api/src/__tests__/helpers.test.js
+++ b/api/src/__tests__/helpers.test.js
@@ -17,8 +17,8 @@ describe('check if uuid is valid', () => {
 describe('check if given reference returns valid check digits', () => {
     
     //examples tested on https://www.mobilefish.com/services/creditor_reference/creditor_reference.php
-    references = ['5496842634654', '12318152 ', 454, '36524564', 78975, '9875614324'];
-    expectedCheckDigits = ['06', '08', '65', '80', '30', '42'];
+    references = ['5496842634654', '12318152 ', 454, '36524564', 78975, '9875614324', '810888428933129078686'];
+    expectedCheckDigits = ['06', '08', '65', '80', '30', '42', '53'];
 
     test('valid references should return the expected check digits', () => {
         references.forEach(function (reference, i) {

--- a/api/src/utils/helpers.js
+++ b/api/src/utils/helpers.js
@@ -22,13 +22,13 @@ const Helpers = {
   }
     
       // Apply the modulo 97 to the invoice number / reference.
-      invoiceNumber = invoiceNumber % 97;
+      invoiceNumber = BigInt(invoiceNumber) % BigInt(97);
       //The european ref number is prefixed by RF as an identifier.
       //R = 27
       //F = 15
       //Next add the translated character digits to the end of the reference followed by '00'.
       //Apply modulo 97 again and subtract the result from 98
-      let checkDigits = 98 - (parseInt(invoiceNumber + "271500") % 97);
+      let checkDigits =  BigInt(98) - (BigInt(invoiceNumber + "271500") % BigInt(97));
       //This result gives you the check digits.
       if (checkDigits == 0) {
           //We always need check digits so if they are 0 we use '00' as check digits.


### PR DESCRIPTION
Fixed a bug that when the number was too big the check digits would be incorrect.